### PR TITLE
use relative file path in unit test

### DIFF
--- a/canvas/src/layer/layer_2d.rs
+++ b/canvas/src/layer/layer_2d.rs
@@ -580,7 +580,7 @@ mod test {
       frame.compose_2d_layer(layer);
     }
 
-    unit_test::assert_canvas_eq!(render, "./test_imgs/text_hello.png");
+    unit_test::assert_canvas_eq!(render, "../../test_imgs/text_hello.png");
   }
 
   #[test]
@@ -651,7 +651,7 @@ And by opposing end them? To die: to sleep;
       frame.compose_2d_layer(layer);
     }
 
-    unit_test::assert_canvas_eq!(render, "./test_imgs/complex_text.png");
+    unit_test::assert_canvas_eq!(render, "../../test_imgs/complex_text.png");
   }
 
   #[test]
@@ -700,7 +700,7 @@ And by opposing end them? To die: to sleep;\n",
       frame.compose_2d_layer(layer);
     }
 
-    unit_test::assert_canvas_eq!(render, "./test_imgs/complex_text_single_style.png");
+    unit_test::assert_canvas_eq!(render, "../../test_imgs/complex_text_single_style.png");
   }
 
   #[test]
@@ -736,6 +736,6 @@ And by opposing end them? To die: to sleep;\n",
       frame.compose_2d_layer(layer);
     }
 
-    unit_test::assert_canvas_eq!(render, "./test_imgs/texture_cache_update.png");
+    unit_test::assert_canvas_eq!(render, "../../test_imgs/texture_cache_update.png");
   }
 }

--- a/canvas/src/text_brush.rs
+++ b/canvas/src/text_brush.rs
@@ -303,8 +303,8 @@ mod tests {
     brush.log_glyph_cache_png_to("glyph_texture_cache.png");
 
     unit_test::assert_img_eq!(
-      "./test_imgs/hello_glyph_cache.png",
-      "./.log/glyph_texture_cache.png"
+      "../test_imgs/hello_glyph_cache.png",
+      "../.log/glyph_texture_cache.png"
     );
   }
 

--- a/canvas/src/wgpu_render.rs
+++ b/canvas/src/wgpu_render.rs
@@ -602,7 +602,8 @@ mod tests {
       let mut frame = canvas.next_frame(&mut render);
       frame.compose_2d_layer(layer);
     }
-    unit_test::assert_canvas_eq!(render, "./test_imgs/smoke_draw_circle.png");
+
+    unit_test::assert_canvas_eq!(render, "../test_imgs/smoke_draw_circle.png");
   }
 
   #[test]
@@ -633,7 +634,7 @@ mod tests {
         frame.compose_2d_layer(layer);
       }
 
-      unit_test::assert_canvas_eq!(render, "./test_imgs/color_palette_texture.png");
+      unit_test::assert_canvas_eq!(render, "../test_imgs/color_palette_texture.png");
     }
   }
 }

--- a/canvas/src/wgpu_render/img_helper.rs
+++ b/canvas/src/wgpu_render/img_helper.rs
@@ -141,14 +141,16 @@ pub(crate) async fn bgra_texture_to_png<W: std::io::Write>(
 
   queue.submit(Some(encoder.finish()));
 
+  let buffer_slice = map_buffer.slice(..);
   // Note that we're not calling `.await` here.
-  let buffer_future = map_buffer.map_async(wgpu::MapMode::Read, 0, wgpu::BufferSize(size));
+
+  let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
 
   // Poll the device in a blocking manner so that our future resolves.
   device.poll(wgpu::Maintain::Wait);
   buffer_future.await.map_err(|_| "Async buffer error")?;
 
-  let data = map_buffer.get_mapped_range(0, wgpu::BufferSize(size));
+  let data = buffer_slice.get_mapped_range();
 
   let mut png_encoder = png::Encoder::new(writer, width, height);
   png_encoder.set_depth(png::BitDepth::Eight);

--- a/unit_test/src/lib.rs
+++ b/unit_test/src/lib.rs
@@ -8,7 +8,7 @@ use futures::executor::block_on;
 use std::sync::{Arc, Mutex};
 
 pub macro write_canvas_to($canvas: expr, $path: expr) {
-  let abs_path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), $path);
+  let abs_path = abs_path!($path);
   let writer = std::fs::File::create(&abs_path).unwrap();
   let _ = block_on($canvas.write_png(writer));
 }
@@ -40,9 +40,19 @@ pub macro assert_img_eq($img1: expr, $img2: expr) {
   }
 }
 
-pub macro file_bytes($path: expr) {{
-  let abs_path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), $path);
-  std::fs::read(abs_path).expect(&format!("{}", $path))
+#[allow(unused_macros)]
+macro file_bytes($path: expr) {{
+  let abs_path = abs_path!($path);
+  std::fs::read(abs_path).expect(&format!("{}", abs_path!($path).to_str().unwrap()))
+}}
+
+#[allow(unused_macros)]
+macro abs_path($path: expr) {{
+  std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+    .with_file_name(file!())
+    .with_file_name($path)
+    .canonicalize()
+    .unwrap()
 }}
 
 #[allow(unused_macros)]


### PR DESCRIPTION
This pr let image unit test use relative path of code file to access resource instead of relative to crate root.